### PR TITLE
WIP: VHG-022 Add SSL support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -339,7 +339,7 @@ single-line-if-stmt=no
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=7
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
@@ -348,10 +348,10 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body
-max-branches=14
+max-branches=15
 
 # Maximum number of locals for function / method body
-max-locals=18
+max-locals=19
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ language: python
 ### Python Build Matrix
 ###
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If you are not satisfied with the `Allow from all` permissions, simply rewrite t
 #### Available command line options
 
 ```shell
-Usage: vhost_gen.py -p|r <str> -n <str> [-l <str> -c <str> -t <str> -o <str> -d -s -v]
+Usage: vhost_gen.py -p|r <str> -n <str> [-l <str> -m <str> -c <str> -t <str> -o <str> -d -s -v]
        vhost_gen.py --help
        vhost_gen.py --version
 
@@ -237,6 +237,11 @@ Required arguments:
               Note, this can also have a prefix and/or suffix to be set in conf.yml
 
 Optional arguments:
+  -m <str>    Vhost generation mode. Possible values are:
+              -m plain: Only generate http version (default)
+              -m ssl:   Only generate https version
+              -m both:  Generate http and https version
+              -m redir: Generate https version and make http redirect to https
   -c <str>    Path to global configuration file.
               If not set, the default location is /etc/vhost-gen/conf.yml
               If no config is found, a default is used with all features turned off.

--- a/bin/vhost_gen.py
+++ b/bin/vhost_gen.py
@@ -99,56 +99,58 @@ TEMPLATES = {
 
 def print_help():
     """Show program help."""
-    print('Usage: vhost_gen.py -p|r <str> -n <str> [-l <str> -c <str> -t <str> -o <str> -d -s -v]')
-    print('       vhost_gen.py --help')
-    print('       vhost_gen.py --version')
-    print('')
-    print('vhost_gen.py will dynamically generate vhost configuration files')
-    print('for Nginx, Apache 2.2 or Apache 2.4 depending on what you have set')
-    print('in /etc/vhot-gen/conf.yml')
-    print('')
-    print('Required arguments:')
-    print('  -p|r <str>  You need to choose one of the mutually exclusive arguments.')
-    print('              -p: Path to document root/')
-    print('              -r: http(s)://Host:Port for reverse proxy.')
-    print('              Depening on the choice, it will either generate a document serving')
-    print('              vhost or a reverse proxy vhost.')
-    print('              Note, when using -p, this can also have a suffix directory to be set')
-    print('              in conf.yml')
-    print('  -l <str>    Location path when using reverse proxy.')
-    print('              Note, this is not required for normal document root server (-p)')
-    print('  -n <str>    Name of vhost')
-    print('              Note, this can also have a prefix and/or suffix to be set in conf.yml')
-    print('')
-    print('Optional arguments:')
-    print('  -m <str>    Vhost generation mode. Possible values are:')
-    print('              -m plain: Only generate http version (default)')
-    print('              -m ssl:   Only generate https version')
-    print('              -m both:  Generate http and https version')
-    print('              -m redir: Generate https version and make http redirect to https')
-    print('  -c <str>    Path to global configuration file.')
-    print('              If not set, the default location is /etc/vhost-gen/conf.yml')
-    print('              If no config is found, a default is used with all features turned off.')
-    print('  -t <str>    Path to global vhost template directory.')
-    print('              If not set, the default location is /etc/vhost-gen/templates/')
-    print('              If vhost template files are not found in this directory, the program will')
-    print('              abort.')
-    print('  -o <str>    Path to local vhost template directory.')
-    print('              This is used as a secondary template directory and definitions found here')
-    print('              will be merged with the ones found in the global template directory.')
-    print('              Note, definitions in local vhost teplate directory take precedence over')
-    print('              the ones found in the global template directory.')
-    print('  -d          Make this vhost the default virtual host.')
-    print('              Note, this will also change the server_name directive of nginx to \'_\'')
-    print('              as well as discarding any prefix or suffix specified for the name.')
-    print('              Apache does not have any specialities, the first vhost takes precedence.')
-    print('  -s          If specified, the generated vhost will be saved in the location found in')
-    print('              conf.yml. If not specified, vhost will be printed to stdout.')
-    print('  -v          Be verbose.')
-    print('')
-    print('Misc arguments:')
-    print('  --help      Show this help.')
-    print('  --version   Show version.')
+    print("""
+Usage: vhost_gen.py -p|r <str> -n <str> [-l <str> -c <str> -t <str> -o <str> -d -s -v]
+       vhost_gen.py --help
+       vhost_gen.py --version
+
+vhost_gen.py will dynamically generate vhost configuration files
+for Nginx, Apache 2.2 or Apache 2.4 depending on what you have set
+in /etc/vhot-gen/conf.yml
+
+Required arguments:
+  -p|r <str>  You need to choose one of the mutually exclusive arguments.
+              -p: Path to document root/
+              -r: http(s)://Host:Port for reverse proxy.
+              Depening on the choice, it will either generate a document serving
+              vhost or a reverse proxy vhost.
+              Note, when using -p, this can also have a suffix directory to be set
+              in conf.yml
+  -l <str>    Location path when using reverse proxy.
+              Note, this is not required for normal document root server (-p)
+  -n <str>    Name of vhost
+              Note, this can also have a prefix and/or suffix to be set in conf.yml
+
+Optional arguments:
+  -m <str>    Vhost generation mode. Possible values are:
+              -m plain: Only generate http version (default)
+              -m ssl:   Only generate https version
+              -m both:  Generate http and https version
+              -m redir: Generate https version and make http redirect to https
+  -c <str>    Path to global configuration file.
+              If not set, the default location is /etc/vhost-gen/conf.yml
+              If no config is found, a default is used with all features turned off.
+  -t <str>    Path to global vhost template directory.
+              If not set, the default location is /etc/vhost-gen/templates/
+              If vhost template files are not found in this directory, the program will
+              abort.
+  -o <str>    Path to local vhost template directory.
+              This is used as a secondary template directory and definitions found here
+              will be merged with the ones found in the global template directory.
+              Note, definitions in local vhost teplate directory take precedence over
+              the ones found in the global template directory.
+  -d          Make this vhost the default virtual host.
+              Note, this will also change the server_name directive of nginx to '_'
+              as well as discarding any prefix or suffix specified for the name.
+              Apache does not have any specialities, the first vhost takes precedence.
+  -s          If specified, the generated vhost will be saved in the location found in
+              conf.yml. If not specified, vhost will be printed to stdout.
+  -v          Be verbose.
+
+Misc arguments:
+  --help      Show this help.
+  --version   Show version.
+""")
 
 
 def print_version():
@@ -423,8 +425,7 @@ def vhost_get_port(config, ssl):
     if ssl:
         if config['server'] == 'nginx':
             return to_str(config['vhost']['ssl_port']) + ' ssl'
-        else:
-            return to_str(config['vhost']['ssl_port'])
+        return to_str(config['vhost']['ssl_port'])
 
     return to_str(config['vhost']['port'])
 
@@ -520,12 +521,14 @@ def vhost_get_vhost_ssl(config, template, server_name):
         '__SSL_CIPHERS__': to_str(config['vhost']['ssl']['ciphers'])
     })
 
+
 def vhost_get_vhost_redir(config, template, server_name):
     """Get redirect to ssl definition."""
     return str_replace(template['features']['redirect'], {
         '__VHOST_NAME__': server_name,
         '__SSL_PORT__':   to_str(config['vhost']['ssl_port'])
     })
+
 
 def vhost_get_ssl_crt_path(config, server_name):
     """Get ssl crt path"""
@@ -537,6 +540,7 @@ def vhost_get_ssl_crt_path(config, server_name):
     path = to_str(config['vhost']['ssl']['dir_crt'])
     return os.path.join(path, name)
 
+
 def vhost_get_ssl_key_path(config, server_name):
     """Get ssl key path"""
     prefix = to_str(config['vhost']['name']['prefix'])
@@ -545,6 +549,7 @@ def vhost_get_ssl_key_path(config, server_name):
 
     path = to_str(config['vhost']['ssl']['dir_crt'])
     return os.path.join(path, name)
+
 
 def vhost_get_docroot_path(config, docroot):
     """Get path of document root."""
@@ -629,7 +634,7 @@ def vhost_get_custom_section(config):
 # vHost create
 ############################################################
 
-def get_vhost_plain(config, tpl, docroot, proxy, mode, location, server_name, default):
+def get_vhost_plain(config, tpl, docroot, proxy, location, server_name, default):
     """Get plain vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, False),
@@ -649,7 +654,8 @@ def get_vhost_plain(config, tpl, docroot, proxy, mode, location, server_name, de
         '__CUSTOM__':        str_indent(vhost_get_custom_section(config), 4)
     })
 
-def get_vhost_ssl(config, tpl, docroot, proxy, mode, location, server_name, default):
+
+def get_vhost_ssl(config, tpl, docroot, proxy, location, server_name, default):
     """Get ssl vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, True),
@@ -669,7 +675,8 @@ def get_vhost_ssl(config, tpl, docroot, proxy, mode, location, server_name, defa
         '__CUSTOM__':        str_indent(vhost_get_custom_section(config), 4)
     })
 
-def get_vhost_redir(config, tpl, docroot, proxy, mode, location, server_name, default):
+
+def get_vhost_redir(config, tpl, server_name, default):
     """Get redirect to ssl vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, False),
@@ -694,27 +701,25 @@ def get_vhost(config, tpl, docroot, proxy, mode, location, server_name, default)
     """Create the vhost."""
 
     if mode == 'ssl':
-        return get_vhost_ssl(config, tpl, docroot, proxy, mode, location,
+        return get_vhost_ssl(config, tpl, docroot, proxy, location,
                              server_name, default)
     elif mode == 'both':
         return (
-            get_vhost_ssl(config, tpl, docroot, proxy, mode, location,
+            get_vhost_ssl(config, tpl, docroot, proxy, location,
                           server_name, default) +
-            get_vhost_plain(config, tpl, docroot, proxy, mode, location,
+            get_vhost_plain(config, tpl, docroot, proxy, location,
                             server_name, default)
         )
 
     elif mode == 'redir':
         return (
-            get_vhost_ssl(config, tpl, docroot, proxy, mode, location,
+            get_vhost_ssl(config, tpl, docroot, proxy, location,
                           server_name, default) +
-            get_vhost_redir(config, tpl, docroot, proxy, mode, location,
-                            server_name, default)
+            get_vhost_redir(config, tpl, server_name, default)
         )
 
-    return get_vhost_plain(config, tpl, docroot, proxy, mode, location,
+    return get_vhost_plain(config, tpl, docroot, proxy, location,
                            server_name, default)
-
 
 
 ############################################################
@@ -851,7 +856,6 @@ def main(argv):
             sys.exit(1)
     else:
         print(vhost)
-
 
 
 ############################################################

--- a/etc/conf.yml
+++ b/etc/conf.yml
@@ -74,6 +74,7 @@ custom:
 vhost:
   # What port should this virtual host listen on
   port: 80
+  ssl_port: 443
 
   # The virtual host name is specified as an command line argument
   # to vhost_gen.py via '-n', however it is possible
@@ -86,6 +87,14 @@ vhost:
   # to prepend another subdirectory here.
   docroot:
     suffix: htdocs
+  # SSL Definition
+  ssl:
+    dir_crt: /etc/httpd/cert
+    dir_key: /etc/httpd/cert
+    protocols: 'TLSv1 TLSv1.1 TLSv1.2'
+    honor_cipher_order: 'on'
+    ciphers: 'HIGH:!aNULL:!MD5'
+
   # Log definition
   log:
     # Log file settings (error/access log)

--- a/etc/templates/apache22.yml
+++ b/etc/templates/apache22.yml
@@ -51,6 +51,8 @@ vhost: |
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"
 
+  __REDIRECT__
+  __SSL__
   __VHOST_DOCROOT__
   __VHOST_RPROXY__
   __PHP_FPM__
@@ -101,6 +103,19 @@ vhost_type:
 ### Optional features to be enabled in vHost
 ###
 features:
+
+  # SSL Configuration
+  ssl: |
+    SSLEngine on
+    SSLCertificateFile    "__SSL_PATH_CRT__"
+    SSLCertificateKeyFile "__SSL_PATH_KEY__"
+    SSLProtocol           __SSL_PROTOCOLS__
+    SSLHonorCipherOrder   __SSL_HONOR_CIPHER_ORDER__
+    SSLCipherSuite        __SSL_CIPHERS__
+
+  # Redirect to SSL directive
+  redirect: |
+    RedirectMatch (.*) https://__VHOST_NAME__:__SSL_PORT__$1
 
   # PHP-FPM will not be applied to a reverse proxy!
   php_fpm: |

--- a/etc/templates/apache24.yml
+++ b/etc/templates/apache24.yml
@@ -51,6 +51,8 @@ vhost: |
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"
 
+  __REDIRECT__
+  __SSL__
   __VHOST_DOCROOT__
   __VHOST_RPROXY__
   __PHP_FPM__
@@ -102,6 +104,19 @@ vhost_type:
 ### Optional features to be enabled in vHost
 ###
 features:
+
+  # SSL Configuration
+  ssl: |
+    SSLEngine on
+    SSLCertificateFile    "__SSL_PATH_CRT__"
+    SSLCertificateKeyFile "__SSL_PATH_KEY__"
+    SSLProtocol           __SSL_PROTOCOLS__
+    SSLHonorCipherOrder   __SSL_HONOR_CIPHER_ORDER__
+    SSLCipherSuite        __SSL_CIPHERS__
+
+  # Redirect to SSL directive
+  redirect: |
+    RedirectMatch (.*) https://__VHOST_NAME__:__SSL_PORT__$1
 
   # PHP-FPM will not be applied to a reverse proxy!
   php_fpm: |

--- a/etc/templates/nginx.yml
+++ b/etc/templates/nginx.yml
@@ -52,6 +52,8 @@ vhost: |
       access_log   "__ACCESS_LOG__" combined;
       error_log    "__ERROR_LOG__" warn;
 
+  __REDIRECT__
+  __SSL__
   __VHOST_DOCROOT__
   __VHOST_RPROXY__
   __PHP_FPM__
@@ -87,6 +89,18 @@ vhost_type:
 ### Optional features to be enabled in vHost
 ###
 features:
+
+  # SSL Configuration
+  ssl: |
+    ssl_certificate           __SSL_PATH_CRT__;
+    ssl_certificate_key       __SSL_PATH_KEY__;
+    ssl_protocols             __SSL_PROTOCOLS__;
+    ssl_prefer_server_ciphers __SSL_HONOR_CIPHER_ORDER__;
+    ssl_ciphers               __SSL_CIPHERS__;
+
+  # Redirect to SSL directive
+  redirect: |
+    return 301 https://__VHOST_NAME__:__SSL_PORT__$request_uri;
 
   # PHP-FPM will not be applied to a reverse proxy!
   php_fpm: |


### PR DESCRIPTION
# SSL support for vhost-gen

This PR will introduce configurable SSL support for vhost-gen.

## Options
The following values can be changed via the configuration file

| Yaml key | Default value |
|---|---|
|  `protocols` | `TLSv1 TLSv1.1 TLSv1.2` |
|  `honor_cipher_order` | `on` |
|  `ciphers` | `HIGH:!aNULL:!MD5` |


## Modes

The following modes can be enabled via command line arguments

| Config | Desc |
|----------|----------|
| `plain` | only serve http |
| `ssl` | only serve https |
| `both` | serve http and https |
| `redir` | redirect all http to https and serve https |


## Dependent projects

Once this has been stabilized, it will need to be backported into the following Docker projects:

* https://github.com/devilbox/docker-nginx-stable
* https://github.com/devilbox/docker-nginx-mainline
* https://github.com/devilbox/docker-apache-2.2
* https://github.com/devilbox/docker-apache-2.4

## Upstream integration

Once the dependent Docker projects are capable of using this feature, it will finally go into the Devilbox:

* https://github.com/cytopia/devilbox