### PR TITLE
Fix PHP-FPM throwing 500, because of no more worker by not releasing them due to reuse

### DIFF
--- a/etc/templates/apache24.yml
+++ b/etc/templates/apache24.yml
@@ -126,8 +126,7 @@ features:
         SetHandler proxy:fcgi://__PHP_ADDR__:__PHP_PORT__
     </FilesMatch>
 
-    # enablereuse requires Apache 2.4.11 or later
-    <Proxy "fcgi://__PHP_ADDR__:__PHP_PORT__/" enablereuse=on max=10>
+    <Proxy "fcgi://__PHP_ADDR__:__PHP_PORT__/">
     </Proxy>
 
     # If the php file doesn't exist, disable the proxy handler.


### PR DESCRIPTION
Fix PHP-FPM throwing 500, because of no more worker by not releasing them due to reuse

This will fix: https://github.com/cytopia/devilbox/issues/234