### PR TITLE
Allow to use HTTP/2 protocol for SSL connections

### DIFF
--- a/bin/vhost_gen.py
+++ b/bin/vhost_gen.py
@@ -56,8 +56,9 @@ DEFAULT_CONFIG = {
             'index.htm'
         ],
         'ssl': {
-            'path_crt': '',
-            'path_key': '',
+            'http2': True,
+            'dir_crt': '',
+            'dir_key': '',
             'honor_cipher_order': 'on',
             'ciphers': 'HIGH:!aNULL:!MD5',
             'protocols': 'TLSv1 TLSv1.1 TLSv1.2'
@@ -436,6 +437,21 @@ def vhost_get_port(config, ssl):
     return to_str(config['vhost']['port'])
 
 
+def vhost_get_http_proto(config, ssl):
+    """Get HTTP protocol. Only relevant for Apache 2.4/Nginx and SSL."""
+
+    if config['server'] == 'apache24':
+        if ssl and config['vhost']['ssl']['http2']:
+            return 'h2 http/1.1'
+        return 'http/1.1'
+
+    if config['server'] == 'nginx':
+        if ssl and config['vhost']['ssl']['http2']:
+            return ' http2'
+
+    return ''
+
+
 def vhost_get_default_server(config, default):
     """
     Get vhost default directive which makes it the default vhost.
@@ -659,6 +675,7 @@ def get_vhost_plain(config, tpl, docroot, proxy, location, server_name, default)
     """Get plain vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, False),
+        '__HTTP_PROTO__':    vhost_get_http_proto(config, False),
         '__DEFAULT_VHOST__': vhost_get_default_server(config, default),
         '__DOCUMENT_ROOT__': vhost_get_docroot_path(config, docroot, proxy),
         '__VHOST_NAME__':    vhost_get_server_name(config, server_name, default),
@@ -681,6 +698,7 @@ def get_vhost_ssl(config, tpl, docroot, proxy, location, server_name, default):
     """Get ssl vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, True),
+        '__HTTP_PROTO__':    vhost_get_http_proto(config, True),
         '__DEFAULT_VHOST__': vhost_get_default_server(config, default),
         '__DOCUMENT_ROOT__': vhost_get_docroot_path(config, docroot, proxy),
         '__VHOST_NAME__':    vhost_get_server_name(config, server_name, default),
@@ -703,6 +721,7 @@ def get_vhost_redir(config, tpl, docroot, proxy, server_name, default):
     """Get redirect to ssl vhost"""
     return str_replace(tpl['vhost'], {
         '__PORT__':          vhost_get_port(config, False),
+        '__HTTP_PROTO__':    vhost_get_http_proto(config, False),
         '__DEFAULT_VHOST__': vhost_get_default_server(config, default),
         '__DOCUMENT_ROOT__': vhost_get_docroot_path(config, docroot, proxy),
         '__VHOST_NAME__':    vhost_get_server_name(config, server_name, default),

--- a/etc/conf.yml
+++ b/etc/conf.yml
@@ -94,6 +94,7 @@ vhost:
     - index.htm
   # SSL Definition
   ssl:
+    http2: True
     dir_crt: /etc/httpd/cert
     dir_key: /etc/httpd/cert
     protocols: 'TLSv1 TLSv1.1 TLSv1.2'

--- a/etc/templates/apache22.yml
+++ b/etc/templates/apache22.yml
@@ -46,7 +46,7 @@
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
-      ServerName   __VHOST_NAME__
+      ServerName __VHOST_NAME__
 
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"

--- a/etc/templates/apache24.yml
+++ b/etc/templates/apache24.yml
@@ -46,7 +46,8 @@
 ###
 vhost: |
   <VirtualHost __DEFAULT_VHOST__:__PORT__>
-      ServerName   __VHOST_NAME__
+      ServerName __VHOST_NAME__
+      Protocols  __HTTP_PROTO__
 
       CustomLog  "__ACCESS_LOG__" combined
       ErrorLog   "__ERROR_LOG__"

--- a/etc/templates/nginx.yml
+++ b/etc/templates/nginx.yml
@@ -46,7 +46,7 @@
 ###
 vhost: |
   server {
-      listen       __PORT____DEFAULT_VHOST__;
+      listen       __PORT____HTTP_PROTO____DEFAULT_VHOST__;
       server_name  __VHOST_NAME__;
 
       access_log   "__ACCESS_LOG__" combined;

--- a/examples/conf.apache22.yml
+++ b/examples/conf.apache22.yml
@@ -94,6 +94,7 @@ vhost:
     - index.htm
   # SSL Definition
   ssl:
+    http2: False
     dir_crt: /etc/httpd/cert
     dir_key: /etc/httpd/cert
     protocols: 'TLSv1 TLSv1.1 TLSv1.2'

--- a/examples/conf.apache24.yml
+++ b/examples/conf.apache24.yml
@@ -94,6 +94,7 @@ vhost:
     - index.htm
   # SSL Definition
   ssl:
+    http2: True
     dir_crt: /etc/httpd/cert
     dir_key: /etc/httpd/cert
     protocols: 'TLSv1 TLSv1.1 TLSv1.2'

--- a/examples/conf.nginx.yml
+++ b/examples/conf.nginx.yml
@@ -94,6 +94,7 @@ vhost:
     - index.htm
   # SSL Definition
   ssl:
+    http2: True
     dir_crt: /etc/httpd/cert
     dir_key: /etc/httpd/cert
     protocols: 'TLSv1 TLSv1.1 TLSv1.2'


### PR DESCRIPTION
# Allow to use HTTP/2 protocol for SSL connections

This PR adds the option to allow to generate SSL vhosts which support HTTP/2

This will only work for Apache 2.4 and Nginx. Apache 2.2 is too old.

* Refs: https://github.com/cytopia/devilbox/issues/431